### PR TITLE
Update dependencies

### DIFF
--- a/Source/Reloaded.Messaging.Host.LiteNetLib/Reloaded.Messaging.Host.LiteNetLib.csproj
+++ b/Source/Reloaded.Messaging.Host.LiteNetLib/Reloaded.Messaging.Host.LiteNetLib.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteNetLib" Version="1.0.0-rc.3" />
+    <PackageReference Include="LiteNetLib" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Reloaded.Messaging.Serializer.MessagePack/Reloaded.Messaging.Serializer.MessagePack.csproj
+++ b/Source/Reloaded.Messaging.Serializer.MessagePack/Reloaded.Messaging.Serializer.MessagePack.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.4.35" />
+    <PackageReference Include="MessagePack" Version="2.5.198" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Reloaded.Messaging.Tests/Reloaded.Messaging.Tests.csproj
+++ b/Source/Reloaded.Messaging.Tests/Reloaded.Messaging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Mainly to resolve the MessagePack vuln popping up in HPP.

Tests pass; Also explicitly added net5 target for testing as a safeguard.
LightNet move from RC1 to latest stable [(no breaking change)](https://github.com/RevenantX/LiteNetLib/releases) - netstandard2.0 is the safeguard.